### PR TITLE
Ruby 2.7

### DIFF
--- a/lib/konfig/option.rb
+++ b/lib/konfig/option.rb
@@ -95,7 +95,6 @@ module Konfig
 
       h.each do |k, v|
         k = k.to_s if !k.respond_to?(:to_sym) && k.respond_to?(:to_s)
-        s.new_ostruct_member(k)
 
         if v.is_a?(Hash)
           v = v["type"] == "hash" ? v["contents"] : __convert(v)


### PR DESCRIPTION
When using ruby 2.7 `Konfig.load` fails with:

```
Failure/Error: Konfig.load

Konfig::KeyError:
  key not found: :new_ostruct_member
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig/option.rb:62:in `method_missing'
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig/option.rb:98:in `block in __convert'
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig/option.rb:96:in `each'
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig/option.rb:96:in `__convert'
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig/option.rb:16:in `load'
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig/yaml_provider.rb:37:in `load'
# ./vendor/bundle/ruby/2.7.0/gems/rb-konfig-0.1.5/lib/konfig.rb:12:in `load'
```

Avoid `new_ostruct_member` usage in `Konfig::Option` seems to be the solution as https://github.com/rubyconfig/config/pull/255/files did.